### PR TITLE
Changing Package Name

### DIFF
--- a/events.go
+++ b/events.go
@@ -1,4 +1,4 @@
-package main
+package events
 
 import (
 	"github.com/centrifuge/go-substrate-rpc-client/types"


### PR DESCRIPTION
- Changing the package name from `main` to `events`. This is to allows imports to the main `chainbridge` project.